### PR TITLE
Fix security issue with external link

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <h1>Aleksei</h1>
         <p>Currently pursuing a PhD in Machine Learning at Bielefeld University.</p>
         <p>
-            Connect with me on <a href="https://www.linkedin.com" target="_blank">LinkedIn</a>.
+            Connect with me on <a href="https://www.linkedin.com/in/aleksei-liuliakov-7528591b3" target="_blank" rel="noopener noreferrer">LinkedIn</a>.
         </p>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- link directly to Aleksei's LinkedIn profile with proper `rel` attribute

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c497160f88327b3851dde8638eac7